### PR TITLE
Backport

### DIFF
--- a/README
+++ b/README
@@ -26,6 +26,15 @@ PyQt5. Install it using:
 
 You also need setuptools to use setup.py for standard installation.
 
+Simpler if you have pip:
+
+    pip install git+https://github.com/pyqtgraph/pyqtgraph.git@develop
+
+or faster:
+
+    pip install https://github.com/pyqtgraph/pyqtgraph/archive/develop.zip
+    
+    
 
 Install
 -------

--- a/dataviz/datasetplot.py
+++ b/dataviz/datasetplot.py
@@ -7,9 +7,9 @@
 # Created: Fri Aug 21 17:21:21 2015 (-0400)
 # Version: 
 # Package-Requires: ()
-# Last-Updated: Thu Aug 27 00:55:11 2015 (-0400)
-#           By: subha
-#     Update #: 817
+# Last-Updated: Thu Sep 17 13:11:04 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 818
 # URL: 
 # Doc URL: 
 # Keywords: 
@@ -46,7 +46,7 @@
 
 import numpy as np
 from collections import defaultdict
-from PyQt5.QtCore import (Qt, pyqtSignal)
+from pyqtgraph import QtCore
 import pyqtgraph as pg
 from pyqtgraph import parametertree as ptree
 import numpy as np
@@ -57,7 +57,7 @@ class DatasetPlotParamTree(ptree.ParameterTree):
     to various dataset types.
 
     """
-    sigUpdateData = pyqtSignal() 
+    sigUpdateData = QtCore.pyqtSignal() 
     
     def __init__(self, parent=None, showHeader=True, dataset=None):
         super().__init__(parent=parent,
@@ -365,12 +365,12 @@ class DatasetPlot(pg.PlotWidget):
 
 import h5py as h5
 from hdfdatasetmodel import (CompoundDatasetModel, NDDatasetModel, TwoDDatasetModel, OneDDatasetModel, create_default_model)
+from pyqtgraph import QtGui
 import sys
-from PyQt5.QtWidgets import (QApplication, QGridLayout, QHBoxLayout, QWidget)
 
 def testDatasetPlotParams(fd):
-    widget = QWidget()
-    widget.setLayout(QHBoxLayout())
+    widget = QtGui.QWidget()
+    widget.setLayout(QtGui.QHBoxLayout())
     onedParams = OneDPlotParamTree(dataset=fd['/data/event/balls/hit/ball_0_9ba91cb6163611e5899524fd526610e7'])
     widget.layout().addWidget(onedParams)
     compoundParams = CompoundPlotParamTree(dataset=fd['/data/static/tables/dimensions'])
@@ -384,7 +384,7 @@ def testDatasetPlotParams(fd):
 
 
 def testDatasetPlot(fd):
-    widget = QWidget()
+    widget = QtGui.QWidget()
     widget.setLayout(QGridLayout())
     oneDimPlot = DatasetPlot()
     plot, params = oneDimPlot.plotLine(fd['/data/event/balls/hit/ball_0_9ba91cb6163611e5899524fd526610e7'])
@@ -406,7 +406,7 @@ def testDatasetPlot(fd):
     return widget
     
 if __name__ == '__main__':
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     with h5.File('poolroom.h5', 'r') as fd:
         dparamw = testDatasetPlotParams(fd)
         dplotw = testDatasetPlot(fd)

--- a/dataviz/datasetplot.py
+++ b/dataviz/datasetplot.py
@@ -7,9 +7,9 @@
 # Created: Fri Aug 21 17:21:21 2015 (-0400)
 # Version: 
 # Package-Requires: ()
-# Last-Updated: Thu Sep 17 13:11:04 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:35:27 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 818
+#     Update #: 827
 # URL: 
 # Doc URL: 
 # Keywords: 
@@ -60,7 +60,7 @@ class DatasetPlotParamTree(ptree.ParameterTree):
     sigUpdateData = QtCore.pyqtSignal() 
     
     def __init__(self, parent=None, showHeader=True, dataset=None):
-        super().__init__(parent=parent,
+        super(DatasetPlotParamTree, self).__init__(parent=parent,
                          showHeader=showHeader)        
         self.dataset = dataset
         self.updatePlotData = ptree.Parameter.create(name='updatePlotData',
@@ -77,7 +77,7 @@ class OneDPlotParamTree(DatasetPlotParamTree):
     """1D datasets can only be plotted as x or y, with the other axis
     being the index."""
     def __init__(self, parent=None, showHeader=True, dataset=None):
-        super().__init__(parent=parent,
+        super(OneDPlotParamTree, self).__init__(parent=parent,
                          showHeader=showHeader,
                          dataset=dataset)
         dataSources = ['index', 'data']
@@ -117,7 +117,7 @@ class CompoundPlotParamTree(OneDPlotParamTree):
 
     """
     def __init__(self, parent=None, showHeader=True, dataset=None):
-        super().__init__(parent=parent,
+        super(CompoundPlotParamTree, self).__init__(parent=parent,
                          showHeader=showHeader,
                          dataset=dataset)
         self.setDataset(dataset)
@@ -146,7 +146,7 @@ class TwoDPlotParamTree(DatasetPlotParamTree):
     """For 2D dataset one can choose data from rows or from columns.
     """
     def __init__(self, parent=None, showHeader=True, dataset=None):
-        super().__init__(parent=parent,
+        super(TwoDPlotParamTree, self).__init__(parent=parent,
                          showHeader=showHeader,
                          dataset=dataset)
         self.dataDim = ptree.Parameter.create(name='datadim',
@@ -201,7 +201,6 @@ class TwoDPlotParamTree(DatasetPlotParamTree):
         ds = self.dataset
         xdim = self.xsource.value()
         ydim = self.ysource.value()
-        print('####', xdim, ydim, self.dataDim.value())
         if self.dataDim.value() == 'rows':
             if xdim == 'index':
                 xdata = range(ds.shape[1])
@@ -226,7 +225,7 @@ class TwoDPlotParamTree(DatasetPlotParamTree):
 class NDPlotParamTree(DatasetPlotParamTree):
     """Class to allow the user to choose parameters for plotting."""
     def __init__(self, parent=None, showHeader=True, dataset=None):
-        super().__init__(parent=parent,
+        super(NDPlotParamTree, self).__init__(parent=parent,
                          showHeader=showHeader,
                          dataset=dataset)
         self.dataDim = ptree.Parameter.create(name='datadim',
@@ -318,7 +317,7 @@ class DatasetPlot(pg.PlotWidget):
     # TODO: multiple dataset in same plotwidget? cannot attach to a
     # specific dataset. Update `name` with something more meaningful. Also, allow option of plo
     def __init__(self, parent=None, background='default', **kwargs):
-        pg.PlotWidget.__init__(self, parent=parent, background=background, **kwargs)
+        super(DatasetPlot, self).__init__(parent=parent, background=background, **kwargs)
         self.name = ''        
         self.plotToParams = {}
         self.paramsToPlots = {}

--- a/dataviz/dataviz.py
+++ b/dataviz/dataviz.py
@@ -8,9 +8,9 @@
 # Maintainer: 
 # Created: Wed Jul 29 22:55:26 2015 (-0400)
 # Version: 
-# Last-Updated: Sat Sep 12 14:31:04 2015 (-0400)
-#           By: subha
-#     Update #: 455
+# Last-Updated: Thu Sep 17 13:12:48 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 456
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -48,20 +48,15 @@
 # Code:
 
 import os
-from PyQt5.QtCore import (Qt, pyqtSignal, QSettings, QPoint, QSize,
-                          QFileInfo)
-from PyQt5.QtWidgets import (QApplication, QTableView, QWidget, QVBoxLayout,
-                             QMainWindow, QDockWidget, QFileDialog,
-                             QAction, QLabel, QMdiArea)
-from PyQt5.QtGui import (QIcon, QKeySequence)
-
-
+from pyqtgraph import QtCore
+from pyqtgraph import QtGui
 from hdftreewidget import HDFTreeWidget
 from hdfdatasetwidget import HDFDatasetWidget
 from datasetplot import (DatasetPlot, DatasetPlotParamTree)
+from pyqtgraph import FileDialog
 
 
-class DataViz(QMainWindow):
+class DataViz(QtGui.QMainWindow):
     """The main application window for dataviz.
 
     This is an MDI application with dock displaying open HDF5 files on
@@ -103,18 +98,18 @@ class DataViz(QMainWindow):
                   contents of the HDF5 node if it is a datset.
 
     """
-    sigOpen = pyqtSignal(list, str)
-    sigCloseFiles = pyqtSignal()
-    sigShowAttributes = pyqtSignal()
-    sigShowDataset = pyqtSignal()
-    sigPlotDataset = pyqtSignal()
+    sigOpen = QtCore.pyqtSignal(list, str)
+    sigCloseFiles = QtCore.pyqtSignal()
+    sigShowAttributes = QtCore.pyqtSignal()
+    sigShowDataset = QtCore.pyqtSignal()
+    sigPlotDataset = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None, flags=Qt.WindowFlags(0)):
+    def __init__(self, parent=None, flags=QtCore.Qt.WindowFlags(0)):
         super().__init__(parent=parent, flags=flags)
         self.readSettings()
-        self.mdiArea = QMdiArea()
-        self.mdiArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        self.mdiArea.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.mdiArea = QtGui.QMdiArea()
+        self.mdiArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.mdiArea.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         self.mdiArea.subWindowActivated.connect(self.switchPlotParamPanel)
         self.setCentralWidget(self.mdiArea)
         self.createActions()
@@ -126,53 +121,79 @@ class DataViz(QMainWindow):
         event.accept()
 
     def readSettings(self):
-        settings = QSettings('dataviz', 'dataviz')
+        settings = QtCore.QSettings('dataviz', 'dataviz')
         self.lastDir = settings.value('lastDir', '.', str)
-        pos = settings.value('pos', QPoint(200, 200))
-        size = settings.value('size', QSize(400, 400))
+        pos = settings.value('pos', QtCore.QPoint(200, 200))
+        size = settings.value('size', QtCore.QSize(400, 400))
         self.move(pos)
         self.resize(size)
 
     def writeSettings(self):
-        settings = QSettings('dataviz', 'dataviz')
+        settings = QtCore.QSettings('dataviz', 'dataviz')
         settings.setValue('lastDir', self.lastDir)
         settings.setValue('pos', self.pos())
         settings.setValue('size', self.size())
 
-    def openFilesReadOnly(self):
-        filePaths, _ = QFileDialog.getOpenFileNames(self, 
-                                                 'Open file(s)', self.lastDir,
+    def openFilesReadOnly(self, filePaths=None):
+        if filePaths is None or filePaths is False:
+            self.fileDialog = FileDialog(None, 'Open file(s) read-only', self.lastDir, 
                                                  'HDF5 file (*.h5 *.hdf);;All files (*)')
+            self.fileDialog.show()
+            self.fileDialog.filesSelected.connect(self.openFilesReadOnly)
+            return
+        # filePaths = QtGui.QFileDialog.getOpenFileNames(self, 
+        #                                          'Open file(s)', self.lastDir,
+        #                                          'HDF5 file (*.h5 *.hdf);;All files (*)')
         if len(filePaths) == 0:
             return
-        self.lastDir = QFileInfo(filePaths[-1]).dir().absolutePath()
+        self.lastDir = QtCore.QFileInfo(filePaths[-1]).dir().absolutePath()
         # TODO handle recent files
         self.sigOpen.emit(filePaths, 'r')
 
-    def openFilesReadWrite(self):
-        filePaths, _ = QFileDialog.getOpenFileNames(self, 
-                                                 'Open file(s)', self.lastDir,
+    def openFilesReadWrite(self, filePaths=None):
+        print(filePaths)
+        if filePaths is None or filePaths is False:
+            self.fileDialog = FileDialog(None, 'Open file(s) read/write', self.lastDir, 
                                                  'HDF5 file (*.h5 *.hdf);;All files (*)')
+            self.fileDialog.filesSelected.connect(self.openFilesReadWrite)
+            self.fileDialog.show()
+            return
+        # filePaths = QtGui.QFileDialog.getOpenFileNames(self, 
+        #                                          'Open file(s)', self.lastDir,
+        #                                          'HDF5 file (*.h5 *.hdf);;All files (*)')
+        print('##', filePaths)
         if len(filePaths) == 0:
             return
-        self.lastDir = QFileInfo(filePaths[-1]).dir().absolutePath()
+        self.lastDir = QtCore.QFileInfo(filePaths[-1]).dir().absolutePath()
         # TODO handle recent files
         self.sigOpen.emit(filePaths, 'r+')
 
-    def openFileOverwrite(self):
-        filePath, _ = QFileDialog.getOpenFileName(self, 
-                                                 'Overwrite file', self.lastDir,
+    def openFileOverwrite(self, filePath=None, startDir=None):
+        if filePath is None or filePaths is False:
+            self.fileDialog = FileDialog(None, 'Open file(s) read/write', self.lastDir, 
                                                  'HDF5 file (*.h5 *.hdf);;All files (*)')
+            self.fileDialog.show()
+            self.fileDialog.fileSelected.connect(self.openFileOverwrite)
+            return
+        # filePath = QtGui.QFileDialog.getOpenFileName(self, 
+        #                                          'Overwrite file', self.lastDir,
+        #                                          'HDF5 file (*.h5 *.hdf);;All files (*)')
         if len(filePath) == 0:
             return
-        self.lastDir = QFileInfo(filePath).dir().absolutePath()
+        self.lastDir = QtCore.QFileInfo(filePath).dir().absolutePath()
         # TODO handle recent files
         self.sigOpen.emit([filePath], 'w')
 
-    def createFile(self):
-        filePath, _ = QFileDialog.getOpenFileName(self, 
-                                                  'Overwrite file', self.lastDir,
-                                                  'HDF5 file (*.h5 *.hdf);;All files (*)')
+    def createFile(self, filePath=None, startDir=None):
+        if filePath is None or filePaths is False:
+            self.fileDialog = FileDialog(None, 'Open file(s) read/write', self.lastDir, 
+                                                 'HDF5 file (*.h5 *.hdf);;All files (*)')
+            self.fileDialog.show()
+            self.fileDialog.fileSelected.connect(self.createFile)
+            return
+        # filePath = QtGui.QFileDialog.getOpenFileName(self, 
+        #                                           'Overwrite file', self.lastDir,
+        #                                           'HDF5 file (*.h5 *.hdf);;All files (*)')
         if len(filePath) == 0:
             return
         print('%%%%%', filePath, _)
@@ -181,41 +202,41 @@ class DataViz(QMainWindow):
         self.sigOpen.emit([filePath], 'w-')
         
     def createActions(self):
-        self.openFileReadOnlyAction = QAction(QIcon(), 'Open file(s) readonly', self,
-                                   # shortcut=QKeySequence.Open,
+        self.openFileReadOnlyAction = QtGui.QAction(QtGui.QIcon(), 'Open file(s) readonly', self,
+                                   # shortcut=QtGui.QKeySequence.Open,
                                    statusTip='Open an HDF5 file for reading',
                                       triggered=self.openFilesReadOnly)
-        self.openFileReadWriteAction = QAction(QIcon(), '&Open file(s) read/write', self,
-                                   shortcut=QKeySequence.Open,
+        self.openFileReadWriteAction = QtGui.QAction(QtGui.QIcon(), '&Open file(s) read/write', self,
+                                   shortcut=QtGui.QKeySequence.Open,
                                    statusTip='Open an HDF5 file for editing',
                                                triggered=self.openFilesReadWrite)
-        self.openFileOverwriteAction = QAction(QIcon(), 'Overwrite file', self,
-                                               # shortcut=QKeySequence.Open,
+        self.openFileOverwriteAction = QtGui.QAction(QtGui.QIcon(), 'Overwrite file', self,
+                                               # shortcut=QtGui.QKeySequence.Open,
                                                statusTip='Open an HDF5 file for writing (overwrite existing)',
                                                triggered=self.openFileOverwrite)
-        self.createFileAction = QAction(QIcon(), '&New file', self,
-                                               shortcut=QKeySequence.New,
+        self.createFileAction = QtGui.QAction(QtGui.QIcon(), '&New file', self,
+                                               shortcut=QtGui.QKeySequence.New,
                                                statusTip='Create a new HDF5 file',
                                                triggered=self.createFile)
-        self.closeFileAction = QAction(QIcon(), '&Close file(s)',
+        self.closeFileAction = QtGui.QAction(QtGui.QIcon(), '&Close file(s)',
                                        self,
-                                       shortcut=QKeySequence(Qt.CTRL+Qt.Key_K),
+                                       shortcut=QtGui.QKeySequence(QtCore.Qt.CTRL+QtCore.Qt.Key_K),
                                        statusTip='Close selected files',
                                        triggered=self.sigCloseFiles)
-        self.quitAction = QAction(QIcon(), '&Quit', self,
-                                  shortcut=QKeySequence.Quit, 
+        self.quitAction = QtGui.QAction(QtGui.QIcon(), '&Quit', self,
+                                  shortcut=QtGui.QKeySequence.Quit, 
                                   statusTip='Quit dataviz', 
                                   triggered=self.doQuit)
-        self.showAttributesAction = QAction(QIcon(), 'Show attributes', self,
-                                            shortcut=QKeySequence.InsertParagraphSeparator,
+        self.showAttributesAction = QtGui.QAction(QtGui.QIcon(), 'Show attributes', self,
+                                            shortcut=QtGui.QKeySequence.InsertParagraphSeparator,
                                             statusTip='Show attributes',
                                             triggered=self.sigShowAttributes)
-        self.showDatasetAction = QAction(QIcon(), 'Show dataset', self,
-                                            shortcut=QKeySequence(Qt.CTRL+Qt.Key_Return),
+        self.showDatasetAction = QtGui.QAction(QtGui.QIcon(), 'Show dataset', self,
+                                            shortcut=QtGui.QKeySequence(QtCore.Qt.CTRL+QtCore.Qt.Key_Return),
                                             statusTip='Show dataset',
                                             triggered=self.sigShowDataset)
-        self.plotDatasetAction = QAction(QIcon(), 'Plot dataset', self,
-                                         shortcut=QKeySequence(Qt.ALT + Qt.Key_P),
+        self.plotDatasetAction = QtGui.QAction(QtGui.QIcon(), 'Plot dataset', self,
+                                         shortcut=QtGui.QKeySequence(QtCore.Qt.ALT + QtCore.Qt.Key_P),
                                          statusTip='Plot dataset',
                                          triggered=self.sigPlotDataset)
         
@@ -237,7 +258,7 @@ class DataViz(QMainWindow):
         self.dataMenu.addAction(self.plotDatasetAction)
 
     def createTreeDock(self):
-        self.treeDock = QDockWidget('File tree', self)
+        self.treeDock = QtGui.QDockWidget('File tree', self)
         self.tree = HDFTreeWidget(parent=self.treeDock)
         self.sigOpen.connect(self.tree.openFiles)
         self.tree.doubleClicked.connect(self.tree.createDatasetWidget)
@@ -254,7 +275,7 @@ class DataViz(QMainWindow):
         self.sigPlotDataset.connect(self.tree.plotDataset)
         self.sigCloseFiles.connect(self.tree.closeFiles)
         self.treeDock.setWidget(self.tree)
-        self.addDockWidget(Qt.LeftDockWidgetArea, self.treeDock)
+        self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.treeDock)
         self.viewMenu.addAction(self.treeDock.toggleViewAction())
 
     def addMdiChildWindow(self, widget):
@@ -271,9 +292,9 @@ class DataViz(QMainWindow):
                     window.deleteLater()
 
     def addPanelBelow(self, widget):
-        dockWidget = QDockWidget(widget.name)
+        dockWidget = QtGui.QDockWidget(widget.name)
         dockWidget.setWidget(widget)
-        self.addDockWidget(Qt.BottomDockWidgetArea, dockWidget)
+        self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, dockWidget)
         dockWidget.show()
 
     
@@ -288,7 +309,7 @@ class DataViz(QMainWindow):
         """
         if subwin is None:
             return
-        for dockWidget in self.findChildren(QDockWidget):
+        for dockWidget in self.findChildren(QtGui.QDockWidget):
             # All dockwidgets that contain paramtrees must be checked
             if isinstance(dockWidget.widget(), DatasetPlotParamTree):
                 if isinstance(subwin.widget(), DatasetPlot) and \
@@ -299,13 +320,12 @@ class DataViz(QMainWindow):
         
     def doQuit(self):
         self.writeSettings()
-        QApplication.instance().closeAllWindows()
+        QtGui.QApplication.instance().closeAllWindows()
         
 
 def main():
     import sys
-    from PyQt5.QtWidgets import (QApplication, QMainWindow, QVBoxLayout, QTreeView, QWidget)
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     window = DataViz()
     window.show()
     app.exec_()

--- a/dataviz/dataviz.py
+++ b/dataviz/dataviz.py
@@ -8,9 +8,9 @@
 # Maintainer: 
 # Created: Wed Jul 29 22:55:26 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:12:48 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:35:35 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 456
+#     Update #: 468
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -105,7 +105,7 @@ class DataViz(QtGui.QMainWindow):
     sigPlotDataset = QtCore.pyqtSignal()
 
     def __init__(self, parent=None, flags=QtCore.Qt.WindowFlags(0)):
-        super().__init__(parent=parent, flags=flags)
+        super(DataViz, self).__init__(parent=parent, flags=flags)
         self.readSettings()
         self.mdiArea = QtGui.QMdiArea()
         self.mdiArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
@@ -124,8 +124,12 @@ class DataViz(QtGui.QMainWindow):
         settings = QtCore.QSettings('dataviz', 'dataviz')
         self.lastDir = settings.value('lastDir', '.', str)
         pos = settings.value('pos', QtCore.QPoint(200, 200))
-        size = settings.value('size', QtCore.QSize(400, 400))
+        if isinstance(pos, QtCore.QVariant):
+            pos = pos.toPyObject()
         self.move(pos)
+        size = settings.value('size', QtCore.QSize(400, 400))
+        if isinstance(size, QtCore.QVariant):
+            size = size.toPyObject()
         self.resize(size)
 
     def writeSettings(self):
@@ -144,6 +148,8 @@ class DataViz(QtGui.QMainWindow):
         # filePaths = QtGui.QFileDialog.getOpenFileNames(self, 
         #                                          'Open file(s)', self.lastDir,
         #                                          'HDF5 file (*.h5 *.hdf);;All files (*)')
+        if isinstance(filePaths, QtCore.QStringList): # python2/qt4 compatibility
+            filePaths = [str(path) for path in filePaths]
         if len(filePaths) == 0:
             return
         self.lastDir = QtCore.QFileInfo(filePaths[-1]).dir().absolutePath()
@@ -161,7 +167,8 @@ class DataViz(QtGui.QMainWindow):
         # filePaths = QtGui.QFileDialog.getOpenFileNames(self, 
         #                                          'Open file(s)', self.lastDir,
         #                                          'HDF5 file (*.h5 *.hdf);;All files (*)')
-        print('##', filePaths)
+        if isinstance(filePaths, QtCore.QStringList): # python2/qt4 compatibility
+            filePaths = [str(path) for path in filePaths]
         if len(filePaths) == 0:
             return
         self.lastDir = QtCore.QFileInfo(filePaths[-1]).dir().absolutePath()

--- a/dataviz/dirreader.py
+++ b/dataviz/dirreader.py
@@ -7,9 +7,9 @@
 # Created: Fri Aug 28 16:43:08 2015 (-0400)
 # Version: 
 # Package-Requires: ()
-# Last-Updated: Thu Sep 17 13:13:09 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:16:21 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 155
+#     Update #: 157
 # URL: 
 # Doc URL: 
 # Keywords: 
@@ -58,7 +58,7 @@ class PathParams(ptree.parameterTypes.GroupParameter):
         opts['type'] = 'group'
         opts['addText'] = "Add rule"
         opts['addList'] = ['timestamp', 'regex', 'string']
-        super().__init__(**opts)
+        super(PathParams, self).__init__(**opts)
 
     def addNew(self, typ):
         val = {'timestamp': 'YYYY-mm-dd HH:MM:SS',
@@ -77,7 +77,7 @@ class PathParams(ptree.parameterTypes.GroupParameter):
 
 class DirReader(QtGui.QWidget):
     def __init__(self, parent=None):
-        super().__init__(parent=parent)        
+        super(DirReader, self).__init__(parent=parent)        
         self.settings = QtCore.QSettings('dataviz', 'dirreader')        
         self.baseDirLabel = QtGui.QLabel('Base directory')
         self.baseDirEdit = QtGui.QLineEdit('.')

--- a/dataviz/dirreader.py
+++ b/dataviz/dirreader.py
@@ -7,9 +7,9 @@
 # Created: Fri Aug 28 16:43:08 2015 (-0400)
 # Version: 
 # Package-Requires: ()
-# Last-Updated: Fri Sep 11 23:39:25 2015 (-0400)
-#           By: subha
-#     Update #: 154
+# Last-Updated: Thu Sep 17 13:13:09 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 155
 # URL: 
 # Doc URL: 
 # Keywords: 
@@ -48,12 +48,10 @@
 """Read data distributed in a directory structure"""
 
 import os
-from PyQt5.QtCore import (Qt, pyqtSignal, QSettings)
-from PyQt5.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QFileDialog)
-from PyQt5.QtGui import (QBrush, QColor)
+from pyqtgraph import (QtCore, QtGui)
 from pyqtgraph import parametertree as ptree
 
-bgBrush = QBrush(QColor('lightsteelblue'))
+bgBrush = QtGui.QBrush(QtGui.QColor('lightsteelblue'))
 
 class PathParams(ptree.parameterTypes.GroupParameter):
     def __init__(self, **opts):
@@ -77,15 +75,15 @@ class PathParams(ptree.parameterTypes.GroupParameter):
             item.setBackground(0, bgBrush)
         
 
-class DirReader(QWidget):
+class DirReader(QtGui.QWidget):
     def __init__(self, parent=None):
         super().__init__(parent=parent)        
-        self.settings = QSettings('dataviz', 'dirreader')        
-        self.baseDirLabel = QLabel('Base directory')
-        self.baseDirEdit = QLineEdit('.')
-        self.baseDirButton = QPushButton('Open')
+        self.settings = QtCore.QSettings('dataviz', 'dirreader')        
+        self.baseDirLabel = QtGui.QLabel('Base directory')
+        self.baseDirEdit = QtGui.QLineEdit('.')
+        self.baseDirButton = QtGui.QPushButton('Open')
         self.baseDirButton.clicked.connect(self.selectBaseDir)
-        self.baseDirWidget = QWidget()
+        self.baseDirWidget = QtGui.QWidget()
         layout = QHBoxLayout()
         self.baseDirWidget.setLayout(layout)
         layout.addWidget(self.baseDirLabel)
@@ -94,7 +92,7 @@ class DirReader(QWidget):
         self.pathTree = ptree.ParameterTree(showHeader=False)
         self.pathRules = PathParams(name='Path rules')
         self.pathTree.setParameters(self.pathRules, showTop=True)
-        self.setLayout(QVBoxLayout())
+        self.setLayout(QtGui.QVBoxLayout())
         self.layout().addWidget(self.baseDirWidget)
         self.layout().addWidget(self.pathTree)
             
@@ -108,13 +106,13 @@ class DirReader(QWidget):
             self.pathRules.restoreState(state)
 
     def selectBaseDir(self):
-        baseDir = QFileDialog.getExistingDirectory()
+        baseDir = QtGui.QFileDialog.getExistingDirectory()
         self.baseDirEdit.setText(baseDir)
         
 import sys
 
 if __name__ == '__main__':
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     widget = DirReader()
     widget.show()
     app.exec()

--- a/dataviz/hdfattributemodel.py
+++ b/dataviz/hdfattributemodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 31 20:48:19 2015 (-0400)
 # Version: 
-# Last-Updated: Wed Aug 26 23:42:28 2015 (-0400)
-#           By: subha
-#     Update #: 119
+# Last-Updated: Thu Sep 17 13:13:27 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 120
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -47,9 +47,9 @@
 
 import numpy as np
 import h5py as h5
-from PyQt5.QtCore import (QAbstractTableModel, QItemSelectionModel, QModelIndex, Qt)
+from pyqtgraph import QtCore
 
-class HDFAttributeModel(QAbstractTableModel):
+class HDFAttributeModel(QtCore.QAbstractTableModel):
     """Model class to handle HDF5 attributes of an HDF5 object"""
     columns = ['Attribute name', 'Value', 'Type']
     def __init__(self, node, parent=None):
@@ -64,7 +64,7 @@ class HDFAttributeModel(QAbstractTableModel):
         return len(HDFAttributeModel.columns)
 
     def headerData(self, section, orientation, role):        
-        if role != Qt.DisplayRole or orientation == Qt.Vertical:
+        if role != QtCore.Qt.DisplayRole or orientation == QtCore.Qt.Vertical:
             return None
         return HDFAttributeModel.columns[section]
 
@@ -75,12 +75,12 @@ class HDFAttributeModel(QAbstractTableModel):
 
         """
         if (not index.isValid()) or \
-           (role not in (Qt.ToolTipRole, Qt.DisplayRole)):
+           (role not in (QtCore.Qt.ToolTipRole, QtCore.Qt.DisplayRole)):
             return None              
         for ii, name in enumerate(self.node.attrs):
             if ii == index.row():
                 break
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             value = self.node.attrs[name]
             # if isinstance(value, bytes) or isinstance(value, str):
             #     return 'string: scalar'
@@ -92,7 +92,7 @@ class HDFAttributeModel(QAbstractTableModel):
                 else:
                     return 'RegionRef: scalar'
             return '{}: scalar'.format(type(value).__name__)
-        elif role == Qt.DisplayRole:
+        elif role == QtCore.Qt.DisplayRole:
             if index.column() == 0:
                 return name
             value = self.node.attrs[name]
@@ -118,14 +118,13 @@ class HDFAttributeModel(QAbstractTableModel):
 if __name__ == '__main__':
     import sys
     import h5py as h5
-    from PyQt5.QtWidgets import (QApplication, QMainWindow, QHBoxLayout, QTreeView, QWidget, QTableView)
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     window = QMainWindow()
-    tabview = QTableView(window)
+    tabview = QtGui.QTableView(window)
     fd = h5.File('poolroom.h5')
     model = HDFAttributeModel(fd)
     tabview.setModel(model)
-    widget = QWidget(window)
+    widget = QtGui.QWidget(window)
     widget.setLayout(QHBoxLayout())
     widget.layout().addWidget(tabview)
     window.setCentralWidget(widget)

--- a/dataviz/hdfattributemodel.py
+++ b/dataviz/hdfattributemodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 31 20:48:19 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:13:27 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:16:32 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 120
+#     Update #: 121
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -54,7 +54,7 @@ class HDFAttributeModel(QtCore.QAbstractTableModel):
     columns = ['Attribute name', 'Value', 'Type']
     def __init__(self, node, parent=None):
         """`node` is an HDF5 object"""
-        super().__init__(parent=parent)
+        super(HDFAttributeModel, self).__init__(parent=parent)
         self.node = node
         
     def rowCount(self, index):

--- a/dataviz/hdfattributewidget.py
+++ b/dataviz/hdfattributewidget.py
@@ -7,9 +7,9 @@
 # Maintainer: 
 # Created: Thu Aug  6 21:46:01 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:13:43 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:16:45 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 80
+#     Update #: 81
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -59,7 +59,7 @@ class HDFAttributeWidget(QtGui.QWidget):
 
     """
     def __init__(self, parent=None, node=None):
-        super().__init__(parent)        
+        super(HDFAttributeWidget, self).__init__(parent)        
         self.name = ''
         self.nameLabel = QtGui.QLabel('', self)
         self.nameLabel.setWordWrap(True)

--- a/dataviz/hdfattributewidget.py
+++ b/dataviz/hdfattributewidget.py
@@ -1,3 +1,4 @@
+
 # hdfattributewidget.py --- 
 # 
 # Filename: hdfattributewidget.py
@@ -6,9 +7,9 @@
 # Maintainer: 
 # Created: Thu Aug  6 21:46:01 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Aug 27 00:18:20 2015 (-0400)
-#           By: subha
-#     Update #: 79
+# Last-Updated: Thu Sep 17 13:13:43 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 80
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -45,12 +46,11 @@
 
 # Code:
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (QTableView, QWidget, QLabel, QVBoxLayout)
+from pyqtgraph import (QtCore, QtGui)
 
 from hdfattributemodel import HDFAttributeModel
 
-class HDFAttributeWidget(QWidget):
+class HDFAttributeWidget(QtGui.QWidget):
     """Convenience widget to display HDF attributes.
 
     It creates a model when dataset is assigned. Like HDFDatasetWidget
@@ -61,14 +61,14 @@ class HDFAttributeWidget(QWidget):
     def __init__(self, parent=None, node=None):
         super().__init__(parent)        
         self.name = ''
-        self.nameLabel = QLabel('', self)
+        self.nameLabel = QtGui.QLabel('', self)
         self.nameLabel.setWordWrap(True)
-        self.nameLabel.setTextInteractionFlags(Qt.TextSelectableByKeyboard | Qt.TextSelectableByMouse)
-        self.fileLabel = QLabel('', self)
+        self.nameLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByKeyboard | QtCore.Qt.TextSelectableByMouse)
+        self.fileLabel = QtGui.QLabel('', self)
         self.fileLabel.setWordWrap(True)
-        self.fileLabel.setTextInteractionFlags(Qt.TextSelectableByKeyboard | Qt.TextSelectableByMouse)
-        self.attributeView = QTableView(self)
-        self.setLayout(QVBoxLayout())
+        self.fileLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByKeyboard | QtCore.Qt.TextSelectableByMouse)
+        self.attributeView = QtGui.QTableView(self)
+        self.setLayout(QtGui.QVBoxLayout())
         self.layout().addWidget(self.nameLabel)
         self.layout().addWidget(self.fileLabel)
         self.layout().addWidget(self.attributeView)

--- a/dataviz/hdfdatasetmodel.py
+++ b/dataviz/hdfdatasetmodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 24 01:52:26 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:14:15 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:17:37 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 439
+#     Update #: 445
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -66,7 +66,7 @@ def datasetType(dataset):
 
 class HDFDatasetModel(QtCore.QAbstractTableModel):
     def __init__(self, dataset, parent=None):
-        super().__init__(parent=parent)
+        super(HDFDatasetModel, self).__init__(parent=parent)
         self.dataset = dataset
 
     def rowCount(self, index):
@@ -89,7 +89,7 @@ class HDFDatasetModel(QtCore.QAbstractTableModel):
  
 class ScalarDatasetModel(HDFDatasetModel):
     def __init__(self, dataset, parent=None):
-        super().__init__(dataset, parent)
+        super(ScalarDatasetModel, self).__init__(dataset, parent)
     
     def rowCount(self, index):
         return 1
@@ -118,7 +118,7 @@ class ScalarDatasetModel(HDFDatasetModel):
 
 class OneDDatasetModel(HDFDatasetModel):
     def __init__(self, dataset, parent=None):
-        super().__init__(dataset, parent)
+        super(OneDDatasetModel, self).__init__(dataset, parent)
 
     def rowCount(self, index):
         return self.dataset.shape[0]
@@ -151,7 +151,7 @@ class OneDDatasetModel(HDFDatasetModel):
 
 class CompoundDatasetModel(HDFDatasetModel):
     def __init__(self, dataset, parent=None):
-        super().__init__(dataset, parent)
+        super(CompoundDatasetModel, self).__init__(dataset, parent)
 
     def rowCount(self, index):
         return self.dataset.shape[0]
@@ -188,7 +188,7 @@ class CompoundDatasetModel(HDFDatasetModel):
 
 class TwoDDatasetModel(HDFDatasetModel):
     def __init__(self, dataset, parent=None):
-        super().__init__(dataset, parent)
+        super(TwoDDatasetModel, self).__init__(dataset, parent)
 
     def rowCount(self, index):
         return self.dataset.shape[0]
@@ -241,7 +241,7 @@ class NDDatasetModel(HDFDatasetModel):
 
     """
     def __init__(self, dataset, parent=None, pos=()):
-        super().__init__(dataset, parent=parent)
+        super(NDDatasetModel, self).__init__(dataset, parent=parent)
         self.select2D(pos)
         
     def rowCount(self, index):

--- a/dataviz/hdfdatasetmodel.py
+++ b/dataviz/hdfdatasetmodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 24 01:52:26 2015 (-0400)
 # Version: 
-# Last-Updated: Sat Aug 22 21:14:08 2015 (-0400)
-#           By: subha
-#     Update #: 438
+# Last-Updated: Thu Sep 17 13:14:15 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 439
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -47,7 +47,7 @@
 """Models for HDF5 datasets"""
 
 import h5py as h5
-from PyQt5.QtCore import (QAbstractTableModel, QItemSelectionModel, QModelIndex, Qt)
+from pyqtgraph import QtCore
 
 
 def datasetType(dataset):
@@ -64,7 +64,7 @@ def datasetType(dataset):
         return 'nd'
 
 
-class HDFDatasetModel(QAbstractTableModel):
+class HDFDatasetModel(QtCore.QAbstractTableModel):
     def __init__(self, dataset, parent=None):
         super().__init__(parent=parent)
         self.dataset = dataset
@@ -98,12 +98,12 @@ class ScalarDatasetModel(HDFDatasetModel):
         return 1
 
     def data(self, index, role):
-        if (role != Qt.DisplayRole and role != Qt.ToolTipRole) \
+        if (role != QtCore.Qt.DisplayRole and role != QtCore.Qt.ToolTipRole) \
            or (not index.isValid()):
             return None
         _data = self.dataset[()] # scalar data
         _data, typename = self.extractDataType(_data)
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             return typename
         return str(_data)
    
@@ -111,7 +111,7 @@ class ScalarDatasetModel(HDFDatasetModel):
         return self.dataset[()]
 
     def headerData(self, section, orientation, role):
-        if role != Qt.DisplayRole:
+        if role != QtCore.Qt.DisplayRole:
             return None
         return section
 
@@ -127,18 +127,18 @@ class OneDDatasetModel(HDFDatasetModel):
         return 1
 
     def headerData(self, section, orientation, role):
-        if role != Qt.DisplayRole:
+        if role != QtCore.Qt.DisplayRole:
             return None
         return section
 
     def data(self, index, role):
-        if (role != Qt.DisplayRole and role != Qt.ToolTipRole) \
+        if (role != QtCore.Qt.DisplayRole and role != QtCore.Qt.ToolTipRole) \
            or (not index.isValid())  \
            or (index.row() > self.dataset.shape[0]):
             return None
         _data = self.dataset[index.row()]
         _data, typename = self.extractDataType(_data)
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             return typename
         return str(_data)
 
@@ -160,9 +160,9 @@ class CompoundDatasetModel(HDFDatasetModel):
         return len(self.dataset.dtype.names)
 
     def headerData(self, section, orientation, role):
-        if role != Qt.DisplayRole:
+        if role != QtCore.Qt.DisplayRole:
             return None
-        if orientation == Qt.Vertical:
+        if orientation == QtCore.Qt.Vertical:
             return section
         names = self.dataset.dtype.names
         if names != None and section < len(names):
@@ -170,13 +170,13 @@ class CompoundDatasetModel(HDFDatasetModel):
         return section
 
     def data(self, index, role):
-        if (role != Qt.DisplayRole and role != Qt.ToolTipRole) \
+        if (role != QtCore.Qt.DisplayRole and role != QtCore.Qt.ToolTipRole) \
            or (not index.isValid()):
             return None
         colname = self.dataset.dtype.names[index.column()]
         _data = self.dataset[colname][index.row()]
         _data, typename = self.extractDataType(_data)
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             return typename
         return str(_data)
 
@@ -197,19 +197,19 @@ class TwoDDatasetModel(HDFDatasetModel):
         return self.dataset.shape[1]
 
     def headerData(self, section, orientation, role):
-        if role != Qt.DisplayRole:
+        if role != QtCore.Qt.DisplayRole:
             return None
         return section
 
     def data(self, index, role):
-        if (role != Qt.DisplayRole and role != Qt.ToolTipRole) \
+        if (role != QtCore.Qt.DisplayRole and role != QtCore.Qt.ToolTipRole) \
            or (not index.isValid())  \
            or (index.row() > self.dataset.shape[0]) \
            or (index.column() > self.dataset.shape[1]):
             return None
         _data = self.dataset[index.row(), index.column()]
         _data, typename = self.extractDataType(_data)
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             return typename
         return str(_data)
 
@@ -251,17 +251,17 @@ class NDDatasetModel(HDFDatasetModel):
         return self.data2D.shape[1]
 
     def headerData(self, section, orientation, role):
-        if role != Qt.DisplayRole:
+        if role != QtCore.Qt.DisplayRole:
             return None
         return section
 
     def data(self, index, role):
-        if (role != Qt.DisplayRole and role != Qt.ToolTipRole) or (not index.isValid()) \
+        if (role != QtCore.Qt.DisplayRole and role != QtCore.Qt.ToolTipRole) or (not index.isValid()) \
            or index.row() < 0 or index.row() > self.data2D.shape[0]:
             return None
         _data = self.data2D[index.row(), index.column()]
         _data, typename = self.extractDataType(_data)
-        if role == Qt.ToolTipRole:
+        if role == QtCore.Qt.ToolTipRole:
             return typename
         return str(_data)
 
@@ -322,30 +322,30 @@ def create_default_model(dataset, parent=None, pos=()):
     else:
         return NDDatasetModel(dataset, parent=parent, pos=())
         
-    
+
+from pyqtgraph import QtGui    
 
 if __name__ == '__main__':
     import sys
-    from PyQt5.QtWidgets import (QApplication, QMainWindow, QHBoxLayout, QTreeView, QWidget, QTableView)
-    app = QApplication(sys.argv)
-    window = QMainWindow()
-    tabview = QTableView(window)
-    fd = h5.File('poolroom.h5')
+    app = QtGui.QApplication(sys.argv)
+    window = QtGui.QMainWindow()
+    tabview = QtGui.QTableView(window)
+    fd = h5.File('poolroom.h5', 'r')
     model = create_default_model(fd['/map/nonuniform/tables/players'])
-    tabview.setModel(model)
-    model2 = create_default_model(fd['/data/uniform/ndim/data3d'], pos=('*', 1, '*'))
-    tabview2 = QTableView(window)
-    tabview2.setModel(model2)
-    model3 = create_default_model(fd['/data/uniform/balls/x'])
-    tabview3 = QTableView(window)
-    tabview3.setModel(model3)
-    widget = QWidget(window)
-    widget.setLayout(QHBoxLayout())
-    widget.layout().addWidget(tabview)
-    widget.layout().addWidget(tabview2)
-    widget.layout().addWidget(tabview3)
-    window.setCentralWidget(widget)
-    window.show()
+    # tabview.setModel(model)
+    # model2 = create_default_model(fd['/data/uniform/ndim/data3d'], pos=('*', 1, '*'))
+    # tabview2 = QtGui.QTableView(window)
+    # tabview2.setModel(model2)
+    # model3 = create_default_model(fd['/data/uniform/balls/x'])
+    # tabview3 = QtGui.QTableView(window)
+    # tabview3.setModel(model3)
+    # widget = QtGui.QWidget(window)
+    # widget.setLayout(QtGui.QHBoxLayout())
+    # widget.layout().addWidget(tabview)
+    # widget.layout().addWidget(tabview2)
+    # widget.layout().addWidget(tabview3)
+    # window.setCentralWidget(widget)
+    # window.show()
     sys.exit(app.exec_())
 
 

--- a/dataviz/hdfdatasetwidget.py
+++ b/dataviz/hdfdatasetwidget.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Wed Jul 29 23:00:06 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:14:26 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:34:27 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 110
+#     Update #: 111
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -61,7 +61,7 @@ class HDFDatasetWidget(QtGui.QTableView):
 
     """
     def __init__(self, parent=None, dataset=None):
-        super().__init__(parent)        
+        super(HDFDatasetWidget, self).__init__(parent)        
         self.name = ''
         if dataset is not None:
             self.setDataset(dataset)

--- a/dataviz/hdfdatasetwidget.py
+++ b/dataviz/hdfdatasetwidget.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Wed Jul 29 23:00:06 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Aug 27 00:16:56 2015 (-0400)
-#           By: subha
-#     Update #: 109
+# Last-Updated: Thu Sep 17 13:14:26 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 110
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -45,15 +45,14 @@
 
 # Code:
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (QTableView, QWidget, QVBoxLayout)
+from pyqtgraph import (QtCore, QtGui)
 
 from hdfdatasetmodel import (HDFDatasetModel, OneDDatasetModel,
                              TwoDDatasetModel, NDDatasetModel,
                              CompoundDatasetModel, ScalarDatasetModel,
                              create_default_model)
 
-class HDFDatasetWidget(QTableView):
+class HDFDatasetWidget(QtGui.QTableView):
     """Convenience widget to display HDF datasets.
 
     It will create a model when the dataset is assigned. Also, it
@@ -79,16 +78,15 @@ class HDFDatasetWidget(QTableView):
 if __name__ == '__main__':
     import sys
     import h5py as h5
-    from PyQt5.QtWidgets import (QApplication, QMainWindow, QHBoxLayout, QWidget)
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     window = QMainWindow()
     fd = h5.File('poolroom.h5', 'r')
     widget1 = HDFDatasetWidget(dataset=fd['/map/nonuniform/tables/players'])
     widget2 = HDFDatasetWidget(dataset=fd['/data/uniform/ndim/data3d'])
     widget3 = HDFDatasetWidget()
     widget3.setDataset(fd['/data/uniform/balls/x'])
-    widget = QWidget(window)
-    layout = QHBoxLayout(widget)
+    widget = QtGui.QWidget(window)
+    layout = QtGui.QHBoxLayout(widget)
     layout.addWidget(widget1)
     layout.addWidget(widget2)
     layout.addWidget(widget3)

--- a/dataviz/hdftreemodel.py
+++ b/dataviz/hdftreemodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Thu Jul 23 22:07:53 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:14:59 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:18:03 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 623
+#     Update #: 626
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -60,7 +60,7 @@ from pyqtgraph import Qt
 
 class RootItem(QtGui.QTreeWidgetItem):
     def __init__(self, parent=None):
-        super().__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
+        super(RootItem, self).__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
         
     def columnCount(self):
         return 1
@@ -89,7 +89,7 @@ class RootItem(QtGui.QTreeWidgetItem):
 
 class HDFTreeItem(QtGui.QTreeWidgetItem):
     def __init__(self, data, parent=None):
-        super().__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
+        super(HDFTreeItem, self).__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
         self.h5node = data
         self.children = []
         
@@ -149,7 +149,7 @@ class HDFTreeItem(QtGui.QTreeWidgetItem):
 
 class EditableItem(HDFTreeItem):    
     def __init__(self, data, parent=None):
-        super().__init__(data, parent)
+        super(EditableItem, self).__init__(data, parent)
         
     def child(self, row):
         if isinstance(self.h5node, h5.Group):

--- a/dataviz/hdftreemodel.py
+++ b/dataviz/hdftreemodel.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Thu Jul 23 22:07:53 2015 (-0400)
 # Version: 
-# Last-Updated: Sat Sep 12 23:32:49 2015 (-0400)
-#           By: subha
-#     Update #: 622
+# Last-Updated: Thu Sep 17 13:14:59 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 623
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -54,20 +54,21 @@ editabletreemodel.py
 
 import os
 import h5py as h5
-from PyQt5.QtCore import (QAbstractItemModel, QItemSelectionModel, QModelIndex, Qt)
-from PyQt5.QtWidgets import QTreeWidgetItem
+from  pyqtgraph import QtCore
+from pyqtgraph import QtGui
+from pyqtgraph import Qt
 
-class RootItem(QTreeWidgetItem):
+class RootItem(QtGui.QTreeWidgetItem):
     def __init__(self, parent=None):
-        super().__init__(parent, type=QTreeWidgetItem.UserType)
+        super().__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
         
     def columnCount(self):
         return 1
 
-    def data(self, column, role=Qt.DisplayRole):
-        if role == Qt.DisplayRole:
+    def data(self, column, role=QtCore.Qt.DisplayRole):
+        if role == QtCore.Qt.DisplayRole:
             return 'Files'
-        elif role == Qt.ToolTipRole:
+        elif role == QtCore.Qt.ToolTipRole:
             return 'List of open files'
 
     def setData(self, column, value):
@@ -86,9 +87,9 @@ class RootItem(QTreeWidgetItem):
     #     return len(children) > 0
 
 
-class HDFTreeItem(QTreeWidgetItem):
+class HDFTreeItem(QtGui.QTreeWidgetItem):
     def __init__(self, data, parent=None):
-        super().__init__(parent, type=QTreeWidgetItem.UserType)
+        super().__init__(parent, type=QtGui.QTreeWidgetItem.UserType)
         self.h5node = data
         self.children = []
         
@@ -108,14 +109,14 @@ class HDFTreeItem(QTreeWidgetItem):
     def columnCount(self):
         return 1
 
-    def data(self, column, role=Qt.DisplayRole):
+    def data(self, column, role=QtCore.Qt.DisplayRole):
         if self.h5node == None:
             return ''
-        if role == Qt.DisplayRole:
+        if role == QtCore.Qt.DisplayRole:
             if isinstance(self.h5node, h5.File):
                 return os.path.basename(self.h5node.filename)
             return self.h5node.name.rsplit('/')[-1]
-        elif role == Qt.ToolTipRole:
+        elif role == QtCore.Qt.ToolTipRole:
             if isinstance(self.h5node, h5.File):
                 return self.h5node.filename
             shape = ''
@@ -221,13 +222,13 @@ class EditableItem(HDFTreeItem):
         pnode.move(self.h5node.name, newName)
 
         
-class HDFTreeModel(QAbstractItemModel):
+class HDFTreeModel(QtCore.QAbstractItemModel):
     def __init__(self, headers, parent=None):
         super(HDFTreeModel, self).__init__(parent)
         rootData = [header for header in headers]
         self.rootItem = RootItem() 
         
-    def columnCount(self, parent=QModelIndex()):
+    def columnCount(self, parent=QtCore.QModelIndex()):
         return self.rootItem.columnCount()
 
     def data(self, index, role):
@@ -246,38 +247,38 @@ class HDFTreeModel(QAbstractItemModel):
     def flags(self, index):
         if not index.isValid():
             return 0
-        return Qt.ItemIsEnabled |Qt.ItemIsSelectable
+        return QtCore.Qt.ItemIsEnabled |QtCore.Qt.ItemIsSelectable
 
-    def headerData(self, section, orientation, role=Qt.DisplayRole):
-        if orientation == Qt.Horizontal:
+    def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
+        if orientation == QtCore.Qt.Horizontal:
             return self.rootItem.data(section, role)
         return None
 
-    def index(self, row, column, parent=QModelIndex()):
+    def index(self, row, column, parent=QtCore.QModelIndex()):
         if parent.isValid() and parent.column()!= 0:
-            return QModelIndex()
+            return QtCore.QModelIndex()
         parentItem = self.getItem(parent)
         childItem = parentItem.child(row)
         if childItem:
             return self.createIndex(row, column, childItem)
         else:
-            return QModelIndex()
+            return QtCore.QModelIndex()
 
     def parent(self, index):
         if not index.isValid():
-            return QModelIndex()        
+            return QtCore.QModelIndex()        
         childItem = self.getItem(index)
         parentItem = childItem.parent()
         if parentItem == self.rootItem: # is the left side childItem or parentItem?
-            return QModelIndex()
+            return QtCore.QModelIndex()
         return self.createIndex(parentItem.parent().indexOfChild(parentItem), 0, parentItem)
 
-    def rowCount(self, parent=QModelIndex()):
+    def rowCount(self, parent=QtCore.QModelIndex()):
         parentItem = self.getItem(parent)
         return parentItem.childCount()
 
     def openFile(self, path, mode='r'):
-        self.beginInsertRows(QModelIndex(),
+        self.beginInsertRows(QtCore.QModelIndex(),
                              self.rootItem.childCount(),
                              self.rootItem.childCount()+1)
         fd = h5.File(str(path), mode=mode)
@@ -294,7 +295,7 @@ class HDFTreeModel(QAbstractItemModel):
         item = self.getItem(index)
         try:
             position = self.rootItem.children.index(item)
-            self.beginRemoveRows(QModelIndex(), position, position+1)
+            self.beginRemoveRows(QtCore.QModelIndex(), position, position+1)
             item.h5node.close()
             self.rootItem.removeChild(position)
             self.endRemoveRows()
@@ -302,28 +303,28 @@ class HDFTreeModel(QAbstractItemModel):
         except ValueError:
             return False
 
-    def insertRows(self, position, rows, parent=QModelIndex()):
+    def insertRows(self, position, rows, parent=QtCore.QModelIndex()):
         parentItem = self.getItem(parent)
         self.beginInsertRows(parent, position, position+rows-1)
         parentItem.insertChildren(position, rows, self.rootItem.columnCount())
         self.endInsertRows()
         return True
 
-    def removeRows(self, position, rows, parent=QModelIndex()):
+    def removeRows(self, position, rows, parent=QtCore.QModelIndex()):
         parentItem = self.getItem(parent)
         self.beginRemoveRows(parent, position, position+rows-1)
         parentItem.removeChildren(position, rows, self.rootItem.columnCount())
         self.endRemoveRows()
         return True
 
-    def insertDataset(self, parent=QModelIndex(), data={}):
+    def insertDataset(self, parent=QtCore.QModelIndex(), data={}):
         parentItem = self.getItem(parent)
         self.beginInsertRows(parent, parentItem.childCount(), 1)
         parentItem.createDataset(data)
         self.endInsertRows()
         return True
 
-    def insertGroup(self, parent=QModelIndex(), data={}):
+    def insertGroup(self, parent=QtCore.QModelIndex(), data={}):
         parentItem = self.getItem(parent)
         self.beginInsertRows(parent, parentItem.childCount(), 1)
         parentItem.createGroup(data)
@@ -341,16 +342,15 @@ class HDFTreeModel(QAbstractItemModel):
 
 if __name__ == '__main__':
     import sys
-    from PyQt5.QtWidgets import (QApplication, QMainWindow, QVBoxLayout, QTreeView, QWidget)
-    app = QApplication(sys.argv)
-    window = QMainWindow()
-    widget = QWidget()
-    layout = QVBoxLayout(widget)
-    view = QTreeView(widget)
+    app = QtGui.QApplication(sys.argv)
+    window = QtGui.QMainWindow()
+    widget = QtGui.QWidget()
+    layout = QtGui.QVBoxLayout(widget)
+    view = QtGui.QTreeView(widget)
     layout.addWidget(view)
     window.setCentralWidget(widget)
     model = HDFTreeModel([])
-    model.openFile('test.h5', 'r+')
+    model.openFile('poolroom.h5', 'r+')
     view.setModel(model)
     window.show()
     sys.exit(app.exec_())

--- a/dataviz/hdftreewidget.py
+++ b/dataviz/hdftreewidget.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 24 20:54:11 2015 (-0400)
 # Version: 
-# Last-Updated: Sat Sep 12 23:34:32 2015 (-0400)
-#           By: subha
-#     Update #: 520
+# Last-Updated: Thu Sep 17 13:15:20 2015 (-0400)
+#           By: Subhasis Ray
+#     Update #: 521
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -52,11 +52,7 @@ from collections import defaultdict
 import numpy as np
 import h5py as h5
 
-from PyQt5.QtCore import (Qt, pyqtSignal)
-from PyQt5.QtWidgets import (QTreeView, QWidget, QTabWidget, QDialog,
-                             QDialogButtonBox, QMessageBox, QMenu,
-                             QVBoxLayout, QAction)
-from PyQt5.QtGui import (QIcon, QBrush, QColor)
+from pyqtgraph import (QtCore, QtGui)
 
 from pyqtgraph import parametertree as ptree
 
@@ -65,7 +61,7 @@ from hdfdatasetwidget import HDFDatasetWidget
 from hdfattributewidget import HDFAttributeWidget
 from datasetplot import DatasetPlot
 
-class HDFTreeWidget(QTreeView):
+class HDFTreeWidget(QtGui.QTreeView):
     """Convenience class to display HDF file trees. 
 
     HDFTreeWidget wraps an HDFTreeModel and displays it.
@@ -98,13 +94,13 @@ class HDFTreeWidget(QTreeView):
     for the widget displaying HDF5 dataset plots.
 
     """
-    sigDatasetWidgetCreated = pyqtSignal(QWidget)
-    sigDatasetWidgetClosed = pyqtSignal(QWidget)
-    sigAttributeWidgetCreated = pyqtSignal(QWidget)
-    sigAttributeWidgetClosed = pyqtSignal(QWidget)
-    sigPlotWidgetCreated = pyqtSignal(QWidget)
-    sigPlotWidgetClosed = pyqtSignal(QWidget)
-    sigPlotParamTreeCreated = pyqtSignal(QWidget)
+    sigDatasetWidgetCreated = QtCore.pyqtSignal(QtGui.QWidget)
+    sigDatasetWidgetClosed = QtCore.pyqtSignal(QtGui.QWidget)
+    sigAttributeWidgetCreated = QtCore.pyqtSignal(QtGui.QWidget)
+    sigAttributeWidgetClosed = QtCore.pyqtSignal(QtGui.QWidget)
+    sigPlotWidgetCreated = QtCore.pyqtSignal(QtGui.QWidget)
+    sigPlotWidgetClosed = QtCore.pyqtSignal(QtGui.QWidget)
+    sigPlotParamTreeCreated = QtCore.pyqtSignal(QtGui.QWidget)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -114,17 +110,17 @@ class HDFTreeWidget(QTreeView):
         self.openAttributeWidgets = defaultdict(set)
         self.openPlotWidgets = defaultdict(set)
         self.createActions()
-        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.showContextMenu)        
 
     def createActions(self):
-        self.insertDatasetAction = QAction(QIcon(), 'Insert dataset', self,
+        self.insertDatasetAction = QtGui.QAction(QtGui.QIcon(), 'Insert dataset', self,
                                            statusTip='Create and insert a dataset under currently selected group',
                                            triggered=self.insertDataset)
-        self.insertGroupAction  = QAction(QIcon(), 'Insert group', self,
+        self.insertGroupAction  = QtGui.QAction(QtGui.QIcon(), 'Insert group', self,
                                            statusTip='Create and insert a group under currently selected group',
                                            triggered=self.insertGroup)
-        self.deleteNodeAction = QAction(QIcon(), 'Delete node', self,
+        self.deleteNodeAction = QtGui.QAction(QtGui.QIcon(), 'Delete node', self,
                                         statusTip='Delete the currently selected node.',
                                         triggered=self.deleteNode)        
 
@@ -219,7 +215,7 @@ class HDFTreeWidget(QTreeView):
         index = self.currentIndex()
         datasetDialog = DatasetDialog()
         ret = datasetDialog.exec_()
-        if ret != QDialog.Accepted:
+        if ret != QtGui.QDialog.Accepted:
             return
         params = datasetDialog.getDatasetParams()
         item = self.model().getItem(index)
@@ -231,7 +227,7 @@ class HDFTreeWidget(QTreeView):
         index = self.currentIndex()
         groupDialog = GroupDialog()
         ret = groupDialog.exec_()
-        if ret != QDialog.Accepted:
+        if ret != QtGui.QDialog.Accepted:
             return
         params = groupDialog.getParams()
         item = self.model().getItem(index)
@@ -254,7 +250,7 @@ class HDFTreeWidget(QTreeView):
             menu.addAction(self.deleteNodeAction)
         menu.exec_(self.mapToGlobal(point))
 
-class DatasetDialog(QDialog):
+class DatasetDialog(QtGui.QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.params = ptree.Parameter.create(name='datasetParameters',
@@ -276,7 +272,7 @@ class DatasetDialog(QDialog):
                                                        {'name': 'chunks',
                                                         'type': 'str',
                                                         'value': 'True'}])
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         paramTree = ptree.ParameterTree(showHeader=False)
         paramTree.setParameters(self.params)
         self.tabWidget = QTabWidget()
@@ -286,7 +282,7 @@ class DatasetDialog(QDialog):
         attrTree.setParameters(self.attrs)
         self.tabWidget.addTab(attrTree, 'Attributes')
         layout.addWidget(self.tabWidget)
-        buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal)
+        buttonBox = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel, QtCore.Qt.Horizontal)
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         layout.addWidget(buttonBox)
@@ -303,7 +299,7 @@ class DatasetDialog(QDialog):
 
 
         
-class GroupDialog(QDialog):
+class GroupDialog(QtGui.QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.params = ptree.Parameter.create(name='groupParameters',
@@ -313,11 +309,11 @@ class GroupDialog(QDialog):
                                                         'value': 'group'},
                                                        XtensibleParam(name='attrs', title='Attributes')])
         
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         paramTree = ptree.ParameterTree(showHeader=False)
         paramTree.setParameters(self.params)
         layout.addWidget(paramTree)
-        buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, Qt.Horizontal)
+        buttonBox = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel, QtCore.Qt.Horizontal)
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         layout.addWidget(buttonBox)
@@ -330,7 +326,7 @@ class GroupDialog(QDialog):
         return opts
 
 
-bgBrush = QBrush(QColor('lightsteelblue'))
+bgBrush = QtGui.QBrush(QtGui.QColor('lightsteelblue'))
 class XtensibleParam(ptree.parameterTypes.GroupParameter):
     def __init__(self, **opts):
         opts['type'] = 'group'
@@ -356,7 +352,7 @@ class XtensibleParam(ptree.parameterTypes.GroupParameter):
 if __name__ == '__main__':
     import sys
     from PyQt5.QtWidgets import (QApplication, QMainWindow)
-    app = QApplication(sys.argv)
+    app = QtGui.QApplication(sys.argv)
     window = QMainWindow()
     widget = HDFTreeWidget()
     window.setCentralWidget(widget)

--- a/dataviz/hdftreewidget.py
+++ b/dataviz/hdftreewidget.py
@@ -6,9 +6,9 @@
 # Maintainer: 
 # Created: Fri Jul 24 20:54:11 2015 (-0400)
 # Version: 
-# Last-Updated: Thu Sep 17 13:15:20 2015 (-0400)
+# Last-Updated: Thu Sep 17 15:33:26 2015 (-0400)
 #           By: Subhasis Ray
-#     Update #: 521
+#     Update #: 526
 # URL: 
 # Keywords: 
 # Compatibility: 
@@ -103,7 +103,7 @@ class HDFTreeWidget(QtGui.QTreeView):
     sigPlotParamTreeCreated = QtCore.pyqtSignal(QtGui.QWidget)
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(HDFTreeWidget, self).__init__(parent)
         model = HDFTreeModel([])
         self.setModel(model)
         self.openDatasetWidgets = defaultdict(set)
@@ -243,7 +243,7 @@ class HDFTreeWidget(QtGui.QTreeView):
             self.model().deleteNode(index)
 
     def showContextMenu(self, point):
-        menu = QMenu()
+        menu = QtGui.QMenu()
         if isinstance(self.model().getItem(self.currentIndex()), EditableItem):
             menu.addAction(self.insertDatasetAction)
             menu.addAction(self.insertGroupAction)
@@ -252,7 +252,7 @@ class HDFTreeWidget(QtGui.QTreeView):
 
 class DatasetDialog(QtGui.QDialog):
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(DatasetDialog, self).__init__(parent)
         self.params = ptree.Parameter.create(name='datasetParameters',
                                              title='Dataset parameters',
                                              type='group',
@@ -301,7 +301,7 @@ class DatasetDialog(QtGui.QDialog):
         
 class GroupDialog(QtGui.QDialog):
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GroupDialog, self).__init__(parent)
         self.params = ptree.Parameter.create(name='groupParameters',
                                              title='Group attributes',
                                              type='group',
@@ -332,7 +332,7 @@ class XtensibleParam(ptree.parameterTypes.GroupParameter):
         opts['type'] = 'group'
         opts['addText'] = "Add"
         opts['addList'] = ['int', 'float', 'str']
-        super().__init__(**opts)
+        super(XtensibleParam, self).__init__(**opts)
 
     def addNew(self, typ):
         val = {'int': '0',


### PR DESCRIPTION
Coded support for PyQt4 via pyqtgraph. 

Decided to switch back to PyQt4 after numerous problems with PyQt5 on Anaconda3 on Win64 platform. Specifically an annoying crash with no information when trying to plot data via pyqtgraph, apart from the fact that installing PyQt5 on Anaconda/Win64 from various out of date personal repos was a PITA.
In stead of writing my own checks for PyQt version, I just used pyqtgraph's Qt module and imports to do this. The code works with little change (mainly imports from PyQt5.XYZ changed to from pyqtgraph import XYZ, also classes in QtWidgets module belonged to QtGui module in PyQt4).
